### PR TITLE
Renaming org.apache.spark.sql.functions.when extension to when_ext to…

### DIFF
--- a/src/main/scala/com/snowflake/snowpark_extensions/Extensions.scala
+++ b/src/main/scala/com/snowflake/snowpark_extensions/Extensions.scala
@@ -548,7 +548,7 @@ object functions {
    * @param result    the value to return if expression is true
    * @return Column object.
    */
-  def when( condition: Column, result:Any) : com.snowflake.snowpark_extensions.implicits.CaseExprExtensions.ExtendedCaseExpr = {
+  def when_ext( condition: Column, result:Any) : com.snowflake.snowpark_extensions.implicits.CaseExprExtensions.ExtendedCaseExpr = {
     new com.snowflake.snowpark_extensions.implicits.CaseExprExtensions.ExtendedCaseExpr(com.snowflake.snowpark.functions.when(condition,lit(result)))
   }
 

--- a/src/test/scala/com/snowflake/snowpark_extensions/implicits/FunctionExtensionsTest.scala
+++ b/src/test/scala/com/snowflake/snowpark_extensions/implicits/FunctionExtensionsTest.scala
@@ -11,12 +11,12 @@ import org.scalatest.{FlatSpec, Matchers}
 class FunctionExtensionsTest extends FlatSpec with Matchers {
   behavior of "FunctionExtenions class"
 
-  "when expression" should "compile without errors" in {
-    when(col("a") > 1,"literal1").otherwise("literal2")
+  "when_ext expression" should "compile without errors" in {
+    when_ext(col("a") > 1,"literal1").otherwise("literal2")
     val session = SessionInitializer.snow
     val df = session.createDataFrame(Seq(("aaaa"))).toDF(Seq("a"))
-    df.withColumn("col1",when(col("a")>1,"a"))
-    df.withColumn("col1",when(col("a")>1,"a").otherwise("b"))
+    df.withColumn("col1",when_ext(col("a")>1,"a"))
+    df.withColumn("col1",when_ext(col("a")>1,"a").otherwise("b"))
   }
 
   "substring_index" should "match spark substring_index" in {


### PR DESCRIPTION
… avoid ambiguity